### PR TITLE
dependency fix

### DIFF
--- a/trivial-irc.asd
+++ b/trivial-irc.asd
@@ -1,13 +1,14 @@
 ;; Copyright (c) 2008 Thomas Stenhaug <thomas.stenhaug@gmail.com>.
 ;; See the LICENSE file for licensing information.
 
-(asdf:defsystem #:trivial-irc 
+(asdf:defsystem #:trivial-irc
   :author "Thomas Stenhaug <thomas.stenhaug@gmail.com>"
   :maintainer "Thomas Stenhaug <thomas.stenhaug@gmail.com>"
   :version "0.0.3"
-  :serial t 
+  :serial t
   :components ((:file "package")
-	       (:file "replies")
-	       (:file "client"))
+               (:file "replies")
+               (:file "client"))
   :depends-on (#:cl-ppcre
-	       #:usocket))
+               #:split-sequence
+               #:usocket))


### PR DESCRIPTION
I tried running trivial-irc with the latest usocket and cl-ppcre. It works but asdf fails with unspecified dependency on split-sequence.
