### PR TITLE
Fix incorrect error message in SERVER slot of CLIENT class.

### DIFF
--- a/client.lisp
+++ b/client.lisp
@@ -163,7 +163,7 @@ disconnected, and the `connection-closed' will be signalled."))
     :initform nil)
    (server
     :initarg :server
-    :initform (error "must supply :nickname"))
+    :initform (error "must supply :server"))
    (socket
     :initarg :socket
     :reader socket)


### PR DESCRIPTION
The CLIENT class has a SERVER slots which must be initialized. Formerly
it signalled error with message "must supply :nickname". Obviously it
should be "must supply :server". This commit fixes the issue
(Closes: #2).
